### PR TITLE
Update proj to Visual Studio 2022 / MonoGame 3.8

### DIFF
--- a/src/MonoGameFrogger/MonoGameFrogger.sln
+++ b/src/MonoGameFrogger/MonoGameFrogger.sln
@@ -1,20 +1,20 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.572
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.34916.146
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGameFrogger", "MonoGameFrogger\MonoGameFrogger.csproj", "{402888C5-C779-47D7-BA97-F7124362430C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x86 = Debug|x86
-		Release|x86 = Release|x86
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{402888C5-C779-47D7-BA97-F7124362430C}.Debug|x86.ActiveCfg = Debug|x86
-		{402888C5-C779-47D7-BA97-F7124362430C}.Debug|x86.Build.0 = Debug|x86
-		{402888C5-C779-47D7-BA97-F7124362430C}.Release|x86.ActiveCfg = Release|x86
-		{402888C5-C779-47D7-BA97-F7124362430C}.Release|x86.Build.0 = Release|x86
+		{402888C5-C779-47D7-BA97-F7124362430C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{402888C5-C779-47D7-BA97-F7124362430C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{402888C5-C779-47D7-BA97-F7124362430C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{402888C5-C779-47D7-BA97-F7124362430C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MonoGameFrogger/MonoGameFrogger/.config/dotnet-tools.json
+++ b/src/MonoGameFrogger/MonoGameFrogger/.config/dotnet-tools.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-mgcb": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb"
+      ]
+    },
+    "dotnet-mgcb-editor": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor"
+      ]
+    },
+    "dotnet-mgcb-editor-linux": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-linux"
+      ]
+    },
+    "dotnet-mgcb-editor-windows": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-windows"
+      ]
+    },
+    "dotnet-mgcb-editor-mac": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-mac"
+      ]
+    }
+  }
+}

--- a/src/MonoGameFrogger/MonoGameFrogger/MonoGameFrogger.csproj
+++ b/src/MonoGameFrogger/MonoGameFrogger/MonoGameFrogger.csproj
@@ -1,115 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{402888C5-C779-47D7-BA97-F7124362430C}</ProjectGuid>
-    <OutputType>WinExe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>MonoGameFrogger</RootNamespace>
-    <AssemblyName>MonoGameFrogger</AssemblyName>
-    <FileAlignment>512</FileAlignment>
-    <MonoGamePlatform>Windows</MonoGamePlatform>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <PlatformTarget>x86</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\$(MonoGamePlatform)\$(Platform)\$(Configuration)\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;WINDOWS</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <PlatformTarget>x86</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\$(MonoGamePlatform)\$(Platform)\$(Configuration)\</OutputPath>
-    <DefineConstants>TRACE;WINDOWS</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ApplicationIcon>Icon.ico</ApplicationIcon>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ApplicationManifest>app.manifest</ApplicationManifest>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="Components\StateComponent.cs" />
-    <Compile Include="Controllers\BaseMovableController.cs" />
-    <Compile Include="Controllers\Cooldown.cs" />
-    <Compile Include="Controllers\FrogAnimation.cs" />
-    <Compile Include="Controllers\GameOverController.cs" />
-    <Compile Include="Controllers\GoalController.cs" />
-    <Compile Include="Controllers\HomeAnimationController.cs" />
-    <Compile Include="Controllers\IController.cs" />
-    <Compile Include="Controllers\IReset.cs" />
-    <Compile Include="Controllers\PlayerController.cs" />
-    <Compile Include="Controllers\ResetMode.cs" />
-    <Compile Include="Controllers\RiverObjectController.cs" />
-    <Compile Include="Controllers\VehicleController.cs" />
-    <Compile Include="Controllers\VehicleDirection.cs" />
-    <Compile Include="Factories\BulldozerFactory.cs" />
-    <Compile Include="Factories\LogFactory.cs" />
-    <Compile Include="Factories\RacingCarFactory.cs" />
-    <Compile Include="Factories\GenericCarFactory.cs" />
-    <Compile Include="Factories\TruckFactory.cs" />
-    <Compile Include="FroggerGame.cs" />
-    <Compile Include="FSM\BaseState.cs" />
-    <Compile Include="FSM\IState.cs" />
-    <Compile Include="FSM\StateMachine.cs" />
-    <Compile Include="General\SpriteSheet.cs" />
-    <Compile Include="General\BitmapFont.cs" />
-    <Compile Include="Models\GameOverModel.cs" />
-    <Compile Include="Models\GoalContainerModel.cs" />
-    <Compile Include="Models\GoalModel.cs" />
-    <Compile Include="Models\PlayerModel.cs" />
-    <Compile Include="Models\RiverRowModel.cs" />
-    <Compile Include="Models\VehicleGhost.cs" />
-    <Compile Include="Models\VehicleModel.cs" />
-    <Compile Include="Models\VehicleRowModel.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="States\GameOverState.cs" />
-    <Compile Include="States\GameState.cs" />
-    <Compile Include="Views\BackgroundView.cs" />
-    <Compile Include="Views\BaseView.cs" />
-    <Compile Include="Views\DebugView.cs" />
-    <Compile Include="Views\FrogPositionView.cs" />
-    <Compile Include="Views\GameOverView.cs" />
-    <Compile Include="Views\GoalView.cs" />
-    <Compile Include="Views\PlayerView.cs" />
-    <Compile Include="Views\ScoreView.cs" />
-    <Compile Include="Views\VehicleView.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="MonoGame.Framework">
-      <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\Windows\MonoGame.Framework.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Icon.ico" />
-  </ItemGroup>
-  <ItemGroup>
-    <MonoGameContentReference Include="Content\Content.mgcb" />
-    <None Include="app.manifest" />
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\MonoGame\v3.0\MonoGame.Content.Builder.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>WinExe</OutputType>
+		<TargetFramework>net6.0-windows</TargetFramework>
+		<RollForward>Major</RollForward>
+		<PublishReadyToRun>false</PublishReadyToRun>
+		<TieredCompilation>false</TieredCompilation>
+		<UseWindowsForms>true</UseWindowsForms>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	</PropertyGroup>
+	<PropertyGroup>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
+		<ApplicationIcon>Icon.ico</ApplicationIcon>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.1.303" />
+		<PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
+	</ItemGroup>
+	<Target Name="RestoreDotnetTools" BeforeTargets="Restore">
+		<Message Text="Restoring dotnet tools" Importance="High" />
+		<Exec Command="dotnet tool restore" />
+	</Target>
 </Project>

--- a/src/MonoGameFrogger/MonoGameFrogger/app.manifest
+++ b/src/MonoGameFrogger/MonoGameFrogger/app.manifest
@@ -36,6 +36,7 @@
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2,permonitor</dpiAwareness>
     </windowsSettings>
   </application>
 


### PR DESCRIPTION
Project file updates to work with Visual Studio 2022 and now uses the latest version of MonoGame